### PR TITLE
docs: small fixes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,33 @@
+This project is a larger work that combines with software written by third
+parties, licensed under their own terms.
+
+Notably, this larger work combines with the following Terraform components,
+which are licensed under the Mozilla Public License 2.0 (see
+<https://www.mozilla.org/en-US/MPL/2.0/> or the individual projects listed
+below).
+<https://github.com/hashicorp/go-getter>
+<https://github.com/hashicorp/vault>
+<https://github.com/hashicorp/errwrap>
+<https://github.com/hashicorp/go-cleanhttp>
+<https://github.com/hashicorp/go-cty>
+<https://github.com/hashicorp/go-hclog>
+<https://github.com/hashicorp/go-multierror>
+<https://github.com/hashicorp/go-safetemp>
+<https://github.com/hashicorp/go-uuid>
+<https://github.com/hashicorp/go-version>
+<https://github.com/hashicorp/hcl>
+<https://github.com/hashicorp/logutils>
+<https://github.com/hashicorp/terraform-plugin-go>
+<https://github.com/hashicorp/terraform-plugin-log>
+<https://github.com/hashicorp/terraform-svchost>
+<https://github.com/hashicorp/go-hclog>
+<https://github.com/hashicorp/go-immutable-radix>
+<https://github.com/hashicorp/go-plugin>
+<https://github.com/hashicorp/go-retryablehttp>
+<https://github.com/hashicorp/go-rootcerts>
+<https://github.com/hashicorp/go-secure-stdlib>
+<https://github.com/hashicorp/go-sockaddr>
+<https://github.com/hashicorp/golang-lru>
+<https://github.com/hashicorp/terraform-plugin-go>
+<https://github.com/hashicorp/terraform-plugin-log>
+<https://github.com/hashicorp/yamux>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -284,6 +284,3 @@ spec:
 At Vault side configuration is also needed to allow the write operation, see
 [example](https://crossplane.io/docs/v1.9/guides/vault-as-secret-store.html#prepare-vault)
 here for inspiration.
-
-A concrete provider terraform use case is also available
-[here](https://github.com/crossplane-contrib/provider-terraform/pull/101).

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -32,9 +32,6 @@ $ up --version
 v0.13.0
 ```
 
-_Note_: official providers only support `up` command-line versions v0.13.0 or
-later.
-
 ## Install Universal Crossplane
 Install Upbound Universal Crossplane with the Up command-line.
 


### PR DESCRIPTION
### Description of your changes

Fixes for @luebken 's feedback:
```
* Link to legal notices points to an empty doc: https://licenses.upbound.io/notice-provider-terraform.html
* Navigation to "Migration guide" doesn't work
* The "Note: official providers only support up command-line versions v0.13.0 or later." is not truthful anymore. Please remove.
* Move contents from "A concrete provider terraform use case is also available here." into the marketplace to github.com/upbound/provider-terraform
```

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
