### PR TITLE
fix VarFileFormatJSON comparison

### DIFF
--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -395,7 +395,7 @@ func (c *external) options(ctx context.Context, p v1beta1.WorkspaceParameters) (
 
 	for _, vf := range p.VarFiles {
 		fmt := terraform.HCL
-		if vf.Format == &v1beta1.VarFileFormatJSON {
+		if vf.Format != nil && *vf.Format == v1beta1.VarFileFormatJSON {
 			fmt = terraform.JSON
 		}
 


### PR DESCRIPTION
Signed-off-by: Harald Skoglund <skoglund@gmail.com>

### Description of your changes


Changes the code as to compare strings instead of comparing memory addresses to check if `v1beta1.Varfile.Format` matches `v1beta1.VarFileFormatJSON` thus enabling loading of a JSON variable file.

Fixes #38 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I've run the following code locally against my test cluster with crossplane 1.10, GKE 1.23.x, 
I've verified that the JSON variable file gets created and picked up. 

I was not able to write or modify the unit tests that checked for this bug. 

The challenge is that workspace.external.options function returns `[]terraform.Option` which the tests for the workspace package can not access to check the output. So further functions to access the data outside the scope of  package `terraform` would need to be added.  I am happy to provide unit tests. But I would require some guidance on how you would like it to be accomplished.

