### PR TITLE
Fix lease name for leader-election

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -84,7 +84,7 @@ func main() {
 		// server. Switching to Leases only and longer leases appears to
 		// alleviate this.
 		LeaderElection:             *leaderElection,
-		LeaderElectionID:           "crossplane-leader-election-provider-template",
+		LeaderElectionID:           "crossplane-leader-election-provider-terraform",
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),
 		RenewDeadline:              func() *time.Duration { d := 50 * time.Second; return &d }(),


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Use the correct lease name for leader-election, which also removes conflicts with the original provider-terraform.

Fixes #57 

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Ran the provider with --leader-election and verified that the lease name is updated:

```
crossplane-leader-election-provider-terraform    provider-terraform-official-45478fa6b48a-55c5779697-6hq7c_c9653083-b070-4569-a778-44a3ef341bdf   3s
```
