### PR TITLE
Defer the semaphore release to ensure it gets called

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,6 @@ require (
 	sigs.k8s.io/controller-tools v0.11.3
 )
 
-replace github.com/crossplane/crossplane-runtime v0.18.0 => github.com/bobh66/crossplane-runtime v0.15.1-0.20230116231839-46d6a0a87fed
-
 require (
 	cloud.google.com/go v0.97.0 // indirect
 	cloud.google.com/go/storage v1.14.0 // indirect

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -145,8 +145,8 @@ func (h Harness) Init(ctx context.Context, cache bool, o ...InitOption) error {
 	if err != nil {
 		return errors.Wrap(err, errSemAcquire)
 	}
+	defer sem.Release(1)
 	_, err = cmd.Output()
-	sem.Release(1)
 	return Classify(err)
 }
 


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Use defer to make sure that sem.Release() gets called even if the terraform init shell command panics and dies

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
The code has run in our development environment with no issues.
