### PR TITLE
Tfenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ spec:
     # Use any module source supported by terraform init -from-module.
     source: Remote
     module: https://github.com/crossplane/tf
+    # Environment variables can be passed through
+    env:
+      - key: TFENV_TERRAFORM_VERSION
+        value: '1.3.5'
     # Variables can be specified inline, or loaded from a ConfigMap or Secret.
     vars:
     - key: region

--- a/apis/v1beta1/workspace_types.go
+++ b/apis/v1beta1/workspace_types.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// A Var represents a Terraform configuration variable.
+// A Var represents a configuration variable.
 type Var struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
@@ -108,6 +108,10 @@ type WorkspaceParameters struct {
 	// Configuration variables.
 	// +optional
 	Vars []Var `json:"vars,omitempty"`
+
+	// Environment variables.
+	// +optional
+	Env []Var `json:"env,omitempty"`
 
 	// Files of configuration variables. Explicitly declared vars take
 	// precedence.

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -446,6 +446,11 @@ func (in *WorkspaceParameters) DeepCopyInto(out *WorkspaceParameters) {
 		*out = make([]Var, len(*in))
 		copy(*out, *in)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]Var, len(*in))
+		copy(*out, *in)
+	}
 	if in.VarFiles != nil {
 		in, out := &in.VarFiles, &out.VarFiles
 		*out = make([]VarFile, len(*in))

--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -3,16 +3,17 @@ RUN apk --no-cache add ca-certificates bash git curl
 ARG TARGETOS
 ARG TARGETARCH
 
-ENV TERRAFORM_VERSION=1.3.7
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
 
 ADD "bin/${TARGETOS}_${TARGETARCH}/provider" /usr/local/bin/crossplane-terraform-provider
 ADD .gitconfig .gitconfig
 
-RUN curl -s -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip | \
-  unzip -d /usr/local/bin - \
-  && chmod +x /usr/local/bin/terraform \
+RUN git clone https://github.com/tfutils/tfenv.git /opt/tfenv \
+  && ln -s /opt/tfenv/bin/* /usr/local/bin \
+  && tfenv use 1.3.7 \
+  && chown -R 2000 /opt/tfenv/version* \
+  && chmod g+rw /opt/tfenv/version* \
   && mkdir -p ${TF_PLUGIN_CACHE_DIR} \
   && chown -R 2000 /tf
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.

--- a/internal/controller/workspace/workspace_test.go
+++ b/internal/controller/workspace/workspace_test.go
@@ -112,7 +112,7 @@ func TestConnect(t *testing.T) {
 		kube      client.Client
 		usage     resource.Tracker
 		fs        afero.Afero
-		terraform func(dir string) tfclient
+		terraform func(dir string, envs ...string) tfclient
 	}
 
 	type args struct {
@@ -204,7 +204,7 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 					}
@@ -243,7 +243,7 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfCreds): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 					}
@@ -282,7 +282,7 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), "subdir", tfCreds): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 					}
@@ -326,7 +326,7 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join("/tmp", tfDir, string(uid), ".git-credentials"): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 					}
@@ -369,7 +369,7 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join("/tmp", tfDir, string(uid)): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 					}
@@ -410,7 +410,7 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfConfig): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 					}
@@ -451,7 +451,7 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), "subdir", tfConfig): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 					}
@@ -487,7 +487,7 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfMain): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 					}
@@ -517,7 +517,7 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{MockInit: func(_ context.Context, cache bool, _ ...terraform.InitOption) error { return errBoom }}
 				},
 			},
@@ -541,7 +541,7 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit:      func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 						MockWorkspace: func(_ context.Context, _ string) error { return errBoom },
@@ -568,7 +568,7 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ ...string) tfclient {
 					return &MockTf{
 						MockInit:      func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
 						MockWorkspace: func(_ context.Context, _ string) error { return nil },

--- a/package/crds/tf.upbound.io_workspaces.yaml
+++ b/package/crds/tf.upbound.io_workspaces.yaml
@@ -78,6 +78,20 @@ spec:
                     default: ""
                     description: Entrypoint for `terraform init` within the module
                     type: string
+                  env:
+                    description: Environment variables.
+                    items:
+                      description: A Var represents a configuration variable.
+                      properties:
+                        key:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
                   initArgs:
                     description: Arguments to be included in the terraform init CLI
                       command
@@ -164,7 +178,7 @@ spec:
                   vars:
                     description: Configuration variables.
                     items:
-                      description: A Var represents a Terraform configuration variable.
+                      description: A Var represents a configuration variable.
                       properties:
                         key:
                           type: string


### PR DESCRIPTION
### Description of your changes

Adds support for [`tfenv`](https://github.com/tfutils/tfenv).  The addition of `tfenv` allows a user to optionally decouple the version of Terraform from the provider image, if we choose or need to do so.  If left alone, the previous behavior is preserved (you get the version which ships with the image)

This allows flexibility in that: we can choose the version of Terraform, and the version of the provider independently, should we choose to do so.

* Decoupling of versions: The Terraform Interface is "relatively" stable now - `tfenv` would allow us to no longer require a specific version of the provider if we want to use a newer/older version of Terraform in my environment. HC decoupled the execution layer (TF) from the control layer very long ago and it dramatically improved the developer experience and the speed of development.

* Enterprise requirements: we test our TF code & modules against specific versions of Terraform and specific versions of TF providers, we want to ensure that we can implement these requirements on the execution layer (Crossplane TF provider).

@danielris
