### PR TITLE
Remove UXP assumption from bug template and cleanup Makefile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ appreciated!
 
 ### What environment did it happen in?
 
-* Universal Crossplane Version:
+* Crossplane Version:
 * Provider Version:
 
 <!--

--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ dev: $(KIND) $(KUBECTL)
 	@$(KUBECTL) cluster-info --context kind-$(PROJECT_NAME)-dev
 	@$(INFO) Installing Crossplane CRDs
 	@$(KUBECTL) apply -k https://github.com/crossplane/crossplane//cluster?ref=master
-	@$(INFO) Installing Provider SQL CRDs
+	@$(INFO) Installing Provider CRDs
 	@$(KUBECTL) apply -R -f package/crds
-	@$(INFO) Starting Provider SQL controllers
+	@$(INFO) Starting Provider controllers
 	@$(GO) run cmd/provider/main.go --debug
 
 dev-clean: $(KIND) $(KUBECTL)


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Updated the bug template to remove the assumption about Universal Crossplane, since this provider is used by both the community and UXP versions of Crossplane.

Removed "SQL" from the provider references in the Makefile dev section

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Ran make dev successfully