### PR TITLE
Add workspace checksum to avoid unnecessary terraform init execution

### DIFF
--- a/apis/v1beta1/workspace_types.go
+++ b/apis/v1beta1/workspace_types.go
@@ -129,7 +129,8 @@ type WorkspaceParameters struct {
 
 // WorkspaceObservation are the observable fields of a Workspace.
 type WorkspaceObservation struct {
-	Outputs map[string]string `json:"outputs,omitempty"`
+	Checksum string            `json:"checksum,omitempty"`
+	Outputs  map[string]string `json:"outputs,omitempty"`
 }
 
 // A WorkspaceSpec defines the desired state of a Workspace.

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -236,6 +236,17 @@ func (h Harness) DeleteCurrentWorkspace(ctx context.Context) error {
 	return Classify(err)
 }
 
+// GenerateChecksum calculates the md5sum of the workspace to see if terraform init needs to run
+func (h Harness) GenerateChecksum(ctx context.Context) (string, error) {
+	command := "/usr/bin/find . -type f -exec /usr/bin/md5sum {} + | LC_ALL=C /usr/bin/sort | /usr/bin/md5sum | /usr/bin/awk '{print $1}'"
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command) //nolint:gosec
+	cmd.Dir = h.Dir
+
+	checksum, err := cmd.Output()
+	result := strings.ReplaceAll(string(checksum), "\n", "")
+	return result, Classify(err)
+}
+
 // An OutputType of Terraform.
 type OutputType int
 

--- a/package/crds/tf.upbound.io_workspaces.yaml
+++ b/package/crds/tf.upbound.io_workspaces.yaml
@@ -356,6 +356,8 @@ spec:
               atProvider:
                 description: WorkspaceObservation are the observable fields of a Workspace.
                 properties:
+                  checksum:
+                    type: string
                   outputs:
                     additionalProperties:
                       type: string


### PR DESCRIPTION
### Description of your changes
Maintain a checksum of the workspace directory content and skip running `terraform init` if the checksum value has not changed since the last reconciliation.

The workspace content is regenerated on every reconciliation so that any changes to the inline or remote workspace, anything in the workspace.spec, the ProviderConfig credentials or configuration will be reflected in the new workspace content and the checksum will be changed accordingly.  If the checksum changes then `terraform init` is re-executed to pick up the new changes.  But if nothing has changed then `terraform init` is redundant and just wastes (a lot of) CPU, and so it can be skipped.

The checksum is stored in the Workspace Status, which does not get updated until after the SECOND reconciliation cycle after creation (status updates on Create are overwritten) so `terraform init` will be executed for the first TWO reconciliations but after that it will only be executed on changes to the content of the workspace/configuration/credentials/etc.

Fixes #81 

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Tested in a development environment running a variety of Workspaces, and verified through logging and timestamp analysis that `terraform init` is only called when expected.