### PR TITLE
Remove dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

With the introduction and activation of Renovate (https://github.com/upbound/provider-terraform/pull/64) we no longer need to have dependabot activated. Renovate is the tool we are standardizing on across all `upbound/provider-*` repos.

