### PR TITLE
Change ProviderConfig credentials to optional

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -25,6 +25,7 @@ import (
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
 type ProviderConfigSpec struct {
 	// Credentials required to authenticate to this provider.
+	// +optional
 	Credentials []ProviderCredentials `json:"credentials"`
 
 	// Configuration that should be injected into all workspaces that use

--- a/package/crds/tf.upbound.io_providerconfigs.yaml
+++ b/package/crds/tf.upbound.io_providerconfigs.yaml
@@ -119,8 +119,6 @@ spec:
                 description: PluginCache enables terraform provider plugin caching
                   mechanism https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
                 type: boolean
-            required:
-            - credentials
             type: object
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.


### PR DESCRIPTION
### Description of your changes
Added the `+optional` annotation to the ProviderConfig credentials attribute since there are use cases where no credentials are required and this was causing users to have to populate "dummy" credential entries just to satisfy the schema.

Fixes #111 

I have:

- [ X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Applied to changes to a test cluster, verified that the ProviderConfig CRD no longer requires the credentials field, updated the default ProviderConfig to remove the dummy credentials entry, and applied a Workspace successfully.