### PR TITLE
Change default pollInterval to 10m

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ You can find a detailed API reference with all CRDs and examples [here](https://
 
 You can find more information about configuring the provider further [here](https://marketplace.upbound.io/providers/upbound/provider-terraform/latest/docs/configuration).
 
+### Polling Interval
+The default polling interval has been updated to 10 minutes from 1 minute.
+This affects how often the provider will run `terraform plan` on existing
+`Workspaces` to determine if there are any resources out of sync and whether
+`terraform apply` needs to be re-executed to recover the desired state.
+A 1 minute polling interval is often too short when the time required for
+running `terrform init`, `terraform plan` and `terraform apply` is taken
+into account.  Workspaces with large numbers of resources can take longer
+than 1 minute to run `terraform plan`.  Changes to the `Workspace` object
+`spec` will still be reconciled immediately.  The poll interval is
+configurable using `ControllerConfig`.
+
 ## Known limitations:
 
 * You must either use remote state or ensure the provider container's `/tf`

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -50,7 +50,7 @@ func main() {
 		app                        = kingpin.New(filepath.Base(os.Args[0]), "Terraform support for Crossplane.").DefaultEnvars()
 		debug                      = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 		syncInterval               = app.Flag("sync", "Sync interval controls how often all resources will be double checked for drift.").Short('s').Default("1h").Duration()
-		pollInterval               = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("1m").Duration()
+		pollInterval               = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("10m").Duration()
 		timeout                    = app.Flag("timeout", "Controls how long Terraform processes may run before they are killed.").Default("20m").Duration()
 		leaderElection             = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
 		maxReconcileRate           = app.Flag("max-reconcile-rate", "The maximum number of concurrent reconciliation operations.").Default("1").Int()


### PR DESCRIPTION
### Description of your changes
Updated the default pollInterval to 10 minutes.  Given the amount of time it takes to run terraform init/plan/apply the default 1m poll interval was likely to expire before the first reconciliation completed.

Users are free to adjust this value using ControllerConfig:

```
spec:
  args:
  - --poll=10m
```

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Applied to changes in a test cluster and verified that reconciliations are requeued with a 10 minute interval by default.
