### PR TITLE
Improve Terraform Error Output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/upbound/provider-terraform
 go 1.19
 
 require (
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/crossplane/crossplane-runtime v0.19.2
 	github.com/crossplane/crossplane-tools v0.0.0-20220310165030-1f43fc12793e
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package terraform
 
 import (
+	"os/exec"
 	"testing"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 )
 
 func TestOutputStringValue(t *testing.T) {
@@ -152,5 +155,136 @@ func TestOutputJSONValue(t *testing.T) {
 				t.Errorf("\no.JSONValue(): -want, +got:\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestClassify(t *testing.T) {
+	tferrs := make(map[string]error)
+	expectedOutput := make(map[string]error)
+
+	tferrs["unexpectedName"] = &exec.ExitError{
+		Stderr: []byte(heredoc.Doc(`
+	│ Error: Unsupported argument
+	│
+	│   on test.tf line 10, in resource "aws_s3_bucket" "example":
+	│   10:   name = "cp-example-${terraform.workspace}-${random_id.example.hex}"
+	│
+	│ An argument named "name" is not expected here.
+	`)),
+	}
+
+	expectedOutput["unexpectedName"] = errors.New(
+		heredoc.Doc(
+			`Terraform encountered an error. Summary: Unsupported argument. To see the full error run: echo "H4sIAAAAAAAA/zyPMWoDMRBFe5/iI1xmhU26hRQpcoTUi6L9jhdbIzEa4QXjxmfwCX2SsGFxMUzzeLz/fNzxpZq1x7fUVkpW44igvy1RbPN83JcDkAXGat4OOE9C7HdvmATKmptGwoVLHer78NPiiebgOIdUznT9KtjvegASEvEBF0u3At32alQNh6zJX7KeagmRt2571SBjTsM0+hX1R84394r6lFfov3eEW57DVCHZwLkwLnOOVPrNHwAAAP//AQAA//+ac3Cu7AAAAA==" | base64 -d | gunzip`,
+		),
+	)
+
+	tferrs["tooManyListItems"] = &exec.ExitError{
+		Stderr: []byte(heredoc.Doc(`
+	│ Error: Too many list items
+	│
+	│   with aws_cognito_user_pool_client.client,
+	│   on main.tf line 21, in resource "aws_cognito_user_pool_client" "client":
+	│   21:   allowed_oauth_flows = jsondecode(base64decode("ICBbIkFMTE9XX0FETUlOX1VTRVJfUEFTU1dPUkRfQVVUSCIsICJBTExPV19SRUZSRVNIX1RPS0VOX0FVVEgiLCAiQUxMT1dfVVNFUl9QQVNTV09SRF9BVVRIIiwgIkFMTE9XX1VTRVJfU1JQX0FVVEgiXQo="))
+	│
+	│ Attribute allowed_oauth_flows supports 3 item maximum, but config has 4 declared.
+	`)),
+	}
+
+	expectedOutput["tooManyListItems"] = errors.New(
+		heredoc.Doc(
+			`Terraform encountered an error. Summary: Too many list items. To see the full error run: echo "H4sIAAAAAAAA/3yRwWrbQBBA7/mKQacGjNGmoSBDDrGQQKZxLGl3Eb2IlbSSt1ntmN0Vcq/5hnyhv6S0lX0qOQwzA8N7zMzl4x0Sa9FugCLCKMwv0Mp5UF6O7u7y8f4nAGBW/ghidnWLg1Ee68lJW58Qdd1qJY1f/0urZR4NjEKZte9BKyPhgaxAGbDS4WRbCcFnrACCpdgsuAeyAQChNc6yq1FM/lj3GmcHT/DToelki5380ggnvz0uTZDF2yZ7S19oElVVmCaU6deKcFrwXc+SlDLSHdhb0eecszLOXBbvtjQ5HziJyoL9KAu+zypSHMqQv1ZhynkyqO/xs8rZ+YWSrud8nzId5TnfUx5GZZFGW86LLFPzcPNefWSXXxlVjk/B/f3tus/eW9VMXv53QTedTmi9g69/nwKjOKtxGlfQTB5aNL0a4CgcPEInWy2s7NZ3vwEAAP//AQAA//9AvYb+1wEAAA==" | base64 -d | gunzip`,
+		),
+	)
+
+	output := Classify(tferrs["unexpectedName"])
+
+	if output.Error() != expectedOutput["unexpectedName"].Error() {
+		t.Errorf("Unexpected error classification got:\n`%s`\nexpected:\n`%s`", output, expectedOutput["unexpectedName"])
+	}
+
+	output = Classify(tferrs["tooManyListItems"])
+
+	if output.Error() != expectedOutput["tooManyListItems"].Error() {
+		t.Errorf("Unexpected error classification got:\n`%s`\nexpected:\n`%s`", output, expectedOutput["tooManyListItems"])
+	}
+}
+
+func TestFormatTerraformErrorOutput(t *testing.T) {
+	tferrs := make(map[string]string)
+	expectedOutput := make(map[string]map[string]string)
+
+	tferrs["unexpectedName"] = heredoc.Doc(`
+	│ Error: Unsupported argument
+	│
+	│   on test.tf line 10, in resource "aws_s3_bucket" "example":
+	│   10:   name = "cp-example-${terraform.workspace}-${random_id.example.hex}"
+	│
+	│ An argument named "name" is not expected here.
+	`)
+
+	expectedOutput["unexpectedName"] = make(map[string]string)
+	expectedOutput["unexpectedName"]["summary"] = heredoc.Doc(`
+	Unsupported argument`)
+
+	expectedOutput["unexpectedName"]["base64full"] = "H4sIAAAAAAAA/zyPMWoDMRBFe5/iI1xmhU26hRQpcoTUi6L9jhdbIzEa4QXjxmfwCX2SsGFxMUzzeLz/fNzxpZq1x7fUVkpW44igvy1RbPN83JcDkAXGat4OOE9C7HdvmATKmptGwoVLHer78NPiiebgOIdUznT9KtjvegASEvEBF0u3At32alQNh6zJX7KeagmRt2571SBjTsM0+hX1R84394r6lFfov3eEW57DVCHZwLkwLnOOVPrNHwAAAP//AQAA//+ac3Cu7AAAAA=="
+
+	tferrs["tooManyListItems"] = heredoc.Doc(`
+	│ Error: Too many list items
+	│
+	│   with aws_cognito_user_pool_client.client,
+	│   on main.tf line 21, in resource "aws_cognito_user_pool_client" "client":
+	│   21:   allowed_oauth_flows = jsondecode(base64decode("ICBbIkFMTE9XX0FETUlOX1VTRVJfUEFTU1dPUkRfQVVUSCIsICJBTExPV19SRUZSRVNIX1RPS0VOX0FVVEgiLCAiQUxMT1dfVVNFUl9QQVNTV09SRF9BVVRIIiwgIkFMTE9XX1VTRVJfU1JQX0FVVEgiXQo="))
+	│
+	│ Attribute allowed_oauth_flows supports 3 item maximum, but config has 4 declared.
+	`)
+
+	expectedOutput["tooManyListItems"] = make(map[string]string)
+	expectedOutput["tooManyListItems"]["summary"] = heredoc.Doc(`
+	Too many list items`)
+
+	expectedOutput["tooManyListItems"]["base64full"] = "H4sIAAAAAAAA/3yRwWrbQBBA7/mKQacGjNGmoSBDDrGQQKZxLGl3Eb2IlbSSt1ntmN0Vcq/5hnyhv6S0lX0qOQwzA8N7zMzl4x0Sa9FugCLCKMwv0Mp5UF6O7u7y8f4nAGBW/ghidnWLg1Ee68lJW58Qdd1qJY1f/0urZR4NjEKZte9BKyPhgaxAGbDS4WRbCcFnrACCpdgsuAeyAQChNc6yq1FM/lj3GmcHT/DToelki5380ggnvz0uTZDF2yZ7S19oElVVmCaU6deKcFrwXc+SlDLSHdhb0eecszLOXBbvtjQ5HziJyoL9KAu+zypSHMqQv1ZhynkyqO/xs8rZ+YWSrud8nzId5TnfUx5GZZFGW86LLFPzcPNefWSXXxlVjk/B/f3tus/eW9VMXv53QTedTmi9g69/nwKjOKtxGlfQTB5aNL0a4CgcPEInWy2s7NZ3vwEAAP//AQAA//9AvYb+1wEAAA=="
+
+	summary, base64FullErr, err := formatTerraformErrorOutput(tferrs["unexpectedName"])
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	if summary != expectedOutput["unexpectedName"]["summary"] {
+		t.Errorf(
+			"Unexpected error summary value got:`%s`\nexpected: `%s`",
+			summary,
+			expectedOutput["unexpectedName"]["summary"],
+		)
+	}
+
+	if base64FullErr != expectedOutput["unexpectedName"]["base64full"] {
+		t.Errorf(
+			"Unexpected error base64full got:`%s`\nexpected: `%s`",
+			base64FullErr,
+			expectedOutput["unexpectedName"]["base64full"],
+		)
+	}
+
+	summary, base64FullErr, err = formatTerraformErrorOutput(tferrs["tooManyListItems"])
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+
+	if summary != expectedOutput["tooManyListItems"]["summary"] {
+		t.Errorf(
+			"Unexpected error classification got:`%s`\nexpected: `%s`",
+			summary,
+			expectedOutput["tooManyListItems"]["summary"],
+		)
+	}
+
+	if base64FullErr != expectedOutput["tooManyListItems"]["base64full"] {
+		t.Errorf(
+			"Unexpected error base64full got:`%s`\nexpected: `%s`",
+			base64FullErr,
+			expectedOutput["tooManyListItems"]["base64full"],
+		)
 	}
 }


### PR DESCRIPTION
An attempt at improving the error output for Terraform by gzipping and base64 encoding the full Terraform error output so as to ensure that nothing is obscured by the provider.

This is an attempt to deal with:

https://github.com/upbound/provider-terraform/issues/37

<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Terraform Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes: #37

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have written tests for the 2 functions that I touched, `Classify` and the new function I created `formatTerraformErrorOutput`. Both are passing.

I could do with being able to create a package that I can deploy into our development cluster to be able to make use of this new error output as I am currently blocked by an error that only seems to occur inside Crossplane's TF provider but couldn't see what it was.