### PR TITLE
BUGFIX: keep environment when plugin cache enabled

### DIFF
--- a/examples/workspace-inline-aws.yaml
+++ b/examples/workspace-inline-aws.yaml
@@ -1,0 +1,33 @@
+apiVersion: tf.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  name: sample-inline
+spec:
+  providerConfigRef:
+    name: aws-eu-west-1
+  forProvider:
+    source: Inline
+    module: |
+      resource "aws_vpc" "main" {
+        cidr_block       = "10.0.0.0/16"
+        tags = {
+          Name = var.vpcName
+        }
+      }
+      resource "aws_subnet" "main" {
+        vpc_id     = aws_vpc.main.id
+        cidr_block = "10.0.1.0/24"
+      }
+      output "vpc_id" {
+        value       = aws_vpc.main.id
+      }
+      output "subnet_id" {
+        value       = aws_subnet.main.id
+      }
+      variable "vpcName" {
+        description = "VPC name"
+        type        = string
+      }
+    vars:
+      - key: vpcName
+        value: sample-tf-inline

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -163,13 +163,13 @@ func (h Harness) Init(ctx context.Context, cache bool, o ...InitOption) error {
 	args := append([]string{"init", "-input=false", "-no-color"}, io.args...)
 	cmd := exec.CommandContext(ctx, h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
-	if !cache {
-		for _, e := range os.Environ() {
-			if strings.Contains(e, "TF_PLUGIN_CACHE_DIR") {
+	for _, e := range os.Environ() {
+		if strings.Contains(e, "TF_PLUGIN_CACHE_DIR") {
+			if !cache {
 				continue
 			}
-			cmd.Env = append(cmd.Env, e)
 		}
+		cmd.Env = append(cmd.Env, e)
 	}
 	cmd.Env = append(cmd.Env, "TF_CLI_CONFIG_FILE=./.terraformrc")
 	err := sem.Acquire(ctx, 1)


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Relates to #109 where we are modifying cmd.Env to enable terraformrc

Before this fix the environment would be stripped with default `pluginCache: true`

In standard k8s backend scenarion the Worskpace is failing with
```
Terraform encountered an error. Summary: Failed to initialize kubernetes configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable.
```

This change always preserves the environment for `cmd.Env` keeping filtering out of `TF_PLUGIN_CACHE_DIR` within the loop.



I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

```
 k apply -f examples/transition/00-mr-tf-workspace/workspace-inline.yaml
```