### PR TITLE
Bump Terraform CLI to v1.5.5

### DIFF
--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -3,14 +3,17 @@ RUN apk --no-cache add ca-certificates bash git curl
 ARG TARGETOS
 ARG TARGETARCH
 
-ENV TERRAFORM_VERSION=1.5.2
+ENV TERRAFORM_VERSION=1.5.5
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
 
 ADD "bin/${TARGETOS}_${TARGETARCH}/provider" /usr/local/bin/crossplane-terraform-provider
 ADD .gitconfig .gitconfig
 
-RUN curl -s -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip -o terraform.zip \
+# Do not change the URL from which the Terraform CLI is downloaded.
+# We are using an MPL-2.0 licensed version of the CLI and
+# we must make sure that this holds true.
+RUN curl -s -L https://github.com/upbound/terraform/releases/download/v${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip -o terraform.zip \
   && unzip -d /usr/local/bin terraform.zip \
   && rm terraform.zip \
   && chmod +x /usr/local/bin/terraform \


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Terraform Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR bumps the Terraform CLI version to `v1.5.5` and consumes it from https://github.com/upbound/terraform/releases.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually tested the provider using Terraform `v1.5.5` using the provider example `examples/workspace-inline-aws.yaml`:
```
❯ k get managed
NAME                                    READY   SYNCED   AGE
workspace.tf.upbound.io/sample-inline   True    True     21s
```

Also verified via the the uptest run [here](https://github.com/upbound/provider-terraform/actions/runs/6004142126).