### PR TITLE
Exclude terraform providers and .git repository when hashing workspace

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -266,9 +266,9 @@ func (h Harness) DeleteCurrentWorkspace(ctx context.Context) error {
 	return Classify(err)
 }
 
-// GenerateChecksum calculates the md5sum of the workspace to see if terraform init needs to run
+// GenerateChecksum calculates the md5sum of the workspace (excluding installed providers) to see if terraform init needs to run
 func (h Harness) GenerateChecksum(ctx context.Context) (string, error) {
-	command := "/usr/bin/find . -type f -exec /usr/bin/md5sum {} + | LC_ALL=C /usr/bin/sort | /usr/bin/md5sum | /usr/bin/awk '{print $1}'"
+	command := "/usr/bin/find . -path ./.terraform/providers -prune -o -type f -exec /usr/bin/md5sum {} + | LC_ALL=C /usr/bin/sort | /usr/bin/md5sum | /usr/bin/awk '{print $1}'"
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command) //nolint:gosec
 	cmd.Dir = h.Dir
 

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -268,7 +268,7 @@ func (h Harness) DeleteCurrentWorkspace(ctx context.Context) error {
 
 // GenerateChecksum calculates the md5sum of the workspace (excluding installed providers) to see if terraform init needs to run
 func (h Harness) GenerateChecksum(ctx context.Context) (string, error) {
-	command := "/usr/bin/find . -path ./.terraform/providers -prune -o -type f -exec /usr/bin/md5sum {} + | LC_ALL=C /usr/bin/sort | /usr/bin/md5sum | /usr/bin/awk '{print $1}'"
+	command := "/usr/bin/find . -path ./.git -prune -o -path ./.terraform/providers -prune -o -type f -exec /usr/bin/md5sum {} + | LC_ALL=C /usr/bin/sort | /usr/bin/md5sum | /usr/bin/awk '{print $1}'"
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command) //nolint:gosec
 	cmd.Dir = h.Dir
 


### PR DESCRIPTION
### Description of your changes

Excludes all files under `.terraform/providers` when computing the workspace checksum, to avoid reading and hashing large provider binaries when the plugin cache is disabled. When the plugin cache is enabled, the providers are stored outside of the workspace directory, and symlinked into the workspace. `find` does not follow symlinks by default, and so the providers are ignored for the checksum. 

This also excludes the `.git` directory to avoid unnecessary `terraform inits` when repository objects change without affecting the working copy used. Fixes #198.

This will cause a (theoretically no-op) `terraform init` in each workspace after upgrading if the plugin cache is disabled or where git is used, as the hash will change due to no longer including the providers and/or `.git` directory.

Relates to #196 (but doesn't entirely fix it - that issue also explores the possibility of using PVCs)

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`kubectl exec`ed into the provider-terraform pod and ran the find command; confirmed that only the provider binaries were excluded compared to the previous command.