### PR TITLE
Add support for jitter

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -52,6 +52,7 @@ func main() {
 		debug                      = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 		syncInterval               = app.Flag("sync", "Sync interval controls how often all resources will be double checked for drift.").Short('s').Default("1h").Duration()
 		pollInterval               = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("10m").Duration()
+		pollJitter                 = app.Flag("poll-jitter", "If non-zero, varies the poll interval by a random amount up to plus-or-minus this value.").Default("1m").Duration()
 		timeout                    = app.Flag("timeout", "Controls how long Terraform processes may run before they are killed.").Default("20m").Duration()
 		leaderElection             = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
 		maxReconcileRate           = app.Flag("max-reconcile-rate", "The maximum number of concurrent reconciliation operations.").Default("1").Int()
@@ -69,7 +70,11 @@ func main() {
 		ctrl.SetLogger(zl)
 	}
 
-	log.Debug("Starting", "sync-period", syncInterval.String())
+	log.Debug("Starting",
+		"sync-period", syncInterval.String(),
+		"poll-interval", pollInterval.String(),
+		"poll-jitter", pollJitter.String(),
+		"max-reconcile-rate", *maxReconcileRate)
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
@@ -123,7 +128,7 @@ func main() {
 		})), "cannot create default store config")
 	}
 
-	kingpin.FatalIfError(workspace.Setup(mgr, o, *timeout), "Cannot setup Workspace controllers")
+	kingpin.FatalIfError(workspace.Setup(mgr, o, *timeout, *pollJitter), "Cannot setup Workspace controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }
 

--- a/internal/controller/terraform.go
+++ b/internal/controller/terraform.go
@@ -29,14 +29,12 @@ import (
 
 // Setup creates all terraform controllers with the supplied options and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options, time.Duration) error{
-		config.Setup,
-		workspace.Setup,
-	} {
-		if err := setup(mgr, o, timeout); err != nil {
-			return err
-		}
+func Setup(mgr ctrl.Manager, o controller.Options, timeout, pollJitter time.Duration) error {
+	if err := config.Setup(mgr, o, timeout); err != nil {
+		return err
+	}
+	if err := workspace.Setup(mgr, o, timeout, pollJitter); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -108,7 +108,7 @@ type tfclient interface {
 }
 
 // Setup adds a controller that reconciles Workspace managed resources.
-func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, o controller.Options, timeout, pollJitter time.Duration) error {
 	name := managed.ControllerName(v1beta1.WorkspaceGroupKind)
 
 	fs := afero.Afero{Fs: afero.NewOsFs()}
@@ -133,6 +133,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(v1beta1.WorkspaceGroupVersionKind),
 		managed.WithPollInterval(o.PollInterval),
+		managed.WithPollJitterHook(pollJitter),
 		managed.WithExternalConnecter(c),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),


### PR DESCRIPTION
### Description of your changes

Add support for jitter in the poll interval, controlled by the `--poll-jitter` flag. This defaults to 1 minute, which is 10% of the default poll interval.

While making this change, I noticed that the `Setup()` method in `internal/controller/terraform.go` is never called - the provider binary calls `workspace.Setup` directly, which means that there is no controller installed for `ProviderConfigs`. I'm not sure if this is intentional.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Ran `make test`.
