### PR TITLE
feat: adding support for defining the backend file content

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -34,6 +34,13 @@ type ProviderConfigSpec struct {
 	// +optional
 	Configuration *string `json:"configuration,omitempty"`
 
+	// Terraform backend file configuration content,
+	// it has the contents of the backend block as top-level attributes,
+	// without the need to wrap it in another terraform or backend block.
+	// More details at https://developer.hashicorp.com/terraform/language/settings/backends/configuration#file.
+	// +optional
+	BackendFile *string `json:"backendFile,omitempty"`
+
 	// PluginCache enables terraform provider plugin caching mechanism
 	// https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
 	// +optional

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -114,6 +114,11 @@ func (in *ProviderConfigSpec) DeepCopyInto(out *ProviderConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.BackendFile != nil {
+		in, out := &in.BackendFile, &out.BackendFile
+		*out = new(string)
+		**out = **in
+	}
 	if in.PluginCache != nil {
 		in, out := &in.PluginCache, &out.PluginCache
 		*out = new(bool)

--- a/examples/providerconfig-backend-file.yaml
+++ b/examples/providerconfig-backend-file.yaml
@@ -1,0 +1,36 @@
+apiVersion: tf.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  # Note that unlike most provider configs this one supports an array of
+  # credentials. This is because each Terraform workspace uses a single
+  # Crossplane provider config, but could use multiple Terraform providers each
+  # with their own credentials.
+  credentials:
+  - filename: gcp-credentials.json
+    source: Secret
+    secretRef:
+      namespace: upbound-system
+      name: gcp-creds
+      key: credentials
+  # This optional configuration block can be used to inject HCL into any
+  # workspace that uses this provider config, for example to setup Terraform
+  # providers.
+  configuration: |
+      provider "google" {
+        credentials = "gcp-credentials.json"
+        project     = "official-provider-testing"
+      }
+
+      // Defining partial backend configuration as documented at 
+      // https://developer.hashicorp.com/terraform/language/settings/backends/configuration#partial-configuration
+      terraform {
+        backend "kubernetes" {}
+      }
+  # Using backend configuration file as documented at
+  # https://developer.hashicorp.com/terraform/language/settings/backends/configuration#file
+  backendFile: |
+    secret_suffix     = "providerconfig-default"
+    namespace         = "upbound-system"
+    in_cluster_config = true

--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -63,6 +63,7 @@ const (
 	errWriteGitCreds   = "cannot write .git-credentials to /tmp dir"
 	errWriteConfig     = "cannot write Terraform configuration " + tfConfig
 	errWriteMain       = "cannot write Terraform configuration " + tfMain
+	errWriteBackend    = "cannot write Terraform configuration " + tfBackendFile
 	errInit            = "cannot initialize Terraform configuration"
 	errWorkspace       = "cannot select Terraform workspace"
 	errResources       = "cannot list Terraform resources"
@@ -81,9 +82,10 @@ const (
 
 const (
 	// TODO(negz): Make the Terraform binary path and work dir configurable.
-	tfPath   = "terraform"
-	tfMain   = "main.tf"
-	tfConfig = "crossplane-provider-config.tf"
+	tfPath        = "terraform"
+	tfMain        = "main.tf"
+	tfConfig      = "crossplane-provider-config.tf"
+	tfBackendFile = "crossplane.remote.tfbackend"
 )
 
 func envVarFallback(envvar string, fallback string) string {
@@ -259,6 +261,12 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		}
 	}
 
+	if pc.Spec.BackendFile != nil {
+		if err := c.fs.WriteFile(filepath.Join(dir, tfBackendFile), []byte(*pc.Spec.BackendFile), 0600); err != nil {
+			return nil, errors.Wrap(err, errWriteBackend)
+		}
+	}
+
 	// NOTE(ytsarev): user tf provider cache mechanism to speed up
 	// reconciliation, see https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache
 	if pc.Spec.PluginCache == nil {
@@ -279,6 +287,9 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	}
 
 	o := make([]terraform.InitOption, 0, len(cr.Spec.ForProvider.InitArgs))
+	if pc.Spec.BackendFile != nil {
+		o = append(o, terraform.WithInitArgs([]string{"-backend-config=" + filepath.Join(dir, tfBackendFile)}))
+	}
 	o = append(o, terraform.WithInitArgs(cr.Spec.ForProvider.InitArgs))
 	if err := tf.Init(ctx, *pc.Spec.PluginCache, o...); err != nil {
 		return nil, errors.Wrap(err, errInit)

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -148,6 +148,15 @@ func WithInitArgs(v []string) InitOption {
 	}
 }
 
+// InitArgsToString converts Terraform init arguments to a list of strings.
+func InitArgsToString(o []InitOption) []string {
+	io := &initOptions{}
+	for _, fn := range o {
+		fn(io)
+	}
+	return io.args
+}
+
 // RWMutex protects the terraform shared cache from corruption. If an init is
 // performed, it requires a write lock. Only one write lock at a time. If another
 // action is performed, a read lock is acquired. More than one read locks can be acquired.
@@ -157,12 +166,7 @@ var rwmutex = &sync.RWMutex{}
 
 // Init initializes a Terraform configuration.
 func (h Harness) Init(ctx context.Context, cache bool, o ...InitOption) error {
-	io := &initOptions{}
-	for _, fn := range o {
-		fn(io)
-	}
-
-	args := append([]string{"init", "-input=false", "-no-color"}, io.args...)
+	args := append([]string{"init", "-input=false", "-no-color"}, InitArgsToString(o)...)
 	cmd := exec.CommandContext(ctx, h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 	for _, e := range os.Environ() {

--- a/package/crds/tf.upbound.io_providerconfigs.yaml
+++ b/package/crds/tf.upbound.io_providerconfigs.yaml
@@ -46,6 +46,12 @@ spec:
           spec:
             description: A ProviderConfigSpec defines the desired state of a ProviderConfig.
             properties:
+              backendFile:
+                description: Terraform backend file configuration content, it has
+                  the contents of the backend block as top-level attributes, without
+                  the need to wrap it in another terraform or backend block. More
+                  details at https://developer.hashicorp.com/terraform/language/settings/backends/configuration#file.
+                type: string
               configuration:
                 description: Configuration that should be injected into all workspaces
                   that use this provider config, expressed as inline HCL. This can


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Terraform Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This changes introduces the `backendFile` field in the `ProviderConfig`, which allows defining the content for the terraform backend configuration file used during `terraform init`.

Fixes #212 

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- The unit tests were evolved to cover a case for the mentioned change
- I have built the provider locally and deployed to a cluster, created a new `ProviderConfig` defining the `backendFile` field and test it in a `Workspace` containing partial backend configuration, I was able to validate the solution is working fine.