### PR TITLE
fix: move from semaphore to rwmutex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.9.5
 	go.uber.org/zap v1.25.0
-	golang.org/x/sync v0.3.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.28.3
 	k8s.io/apiextensions-apiserver v0.28.3
@@ -87,6 +86,7 @@ require (
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -151,7 +151,7 @@ func WithInitArgs(v []string) InitOption {
 // RWMutex protects the terraform shared cache from corruption. If an init is
 // performed, it requires a write lock. Only one write lock at a time. If another
 // action is performed, a read lock is acquired. More than one read locks can be acquired.
-// This prevents an init from inadvertantly changing a plugin while it's in use.
+// This prevents an init from inadvertently changing a plugin while it's in use.
 // Prevents issues with `text file busy` errors.
 var rwmutex = &sync.RWMutex{}
 

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -33,16 +33,15 @@ import (
 	"strconv"
 	"strings"
 
+	"sync"
+
 	"github.com/pkg/errors"
-	"golang.org/x/sync/semaphore"
 )
 
 // Error strings.
 const (
-	errParse        = "cannot parse Terraform output"
-	errWriteVarFile = "cannot write tfvars file"
-	errSemAcquire   = "cannot acquire semaphore for tfinit"
-
+	errParse            = "cannot parse Terraform output"
+	errWriteVarFile     = "cannot write tfvars file"
 	errFmtInvalidConfig = "invalid Terraform configuration: found %d errors"
 
 	tfDefault = "default"
@@ -149,9 +148,12 @@ func WithInitArgs(v []string) InitOption {
 	}
 }
 
-// Semaphore to limit the number of concurrent terraform init commands to 1.
-// This is needed to support a shared provider cache with concurrent reconciliations.
-var sem = semaphore.NewWeighted(int64(1))
+// RWMutex protects the terraform shared cache from corruption. If an init is
+// performed, it requires a write lock. Only one write lock at a time. If another
+// action is performed, a read lock is acquired. More than one read locks can be acquired.
+// This prevents an init from inadvertantly changing a plugin while it's in use.
+// Prevents issues with `text file busy` errors.
+var rwmutex = &sync.RWMutex{}
 
 // Init initializes a Terraform configuration.
 func (h Harness) Init(ctx context.Context, cache bool, o ...InitOption) error {
@@ -172,12 +174,9 @@ func (h Harness) Init(ctx context.Context, cache bool, o ...InitOption) error {
 		cmd.Env = append(cmd.Env, e)
 	}
 	cmd.Env = append(cmd.Env, "TF_CLI_CONFIG_FILE=./.terraformrc")
-	err := sem.Acquire(ctx, 1)
-	if err != nil {
-		return errors.Wrap(err, errSemAcquire)
-	}
-	defer sem.Release(1)
-	_, err = cmd.Output()
+	rwmutex.Lock()
+	defer rwmutex.Unlock()
+	_, err := cmd.Output()
 	return Classify(err)
 }
 
@@ -231,6 +230,8 @@ func (h Harness) Workspace(ctx context.Context, name string) error {
 	// is somewhat optimistic, but it shouldn't hurt to try.
 	cmd = exec.CommandContext(ctx, h.Path, "workspace", "new", "-no-color", name) //nolint:gosec
 	cmd.Dir = h.Dir
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
 	_, err := cmd.Output()
 	return Classify(err)
 }
@@ -257,6 +258,8 @@ func (h Harness) DeleteCurrentWorkspace(ctx context.Context) error {
 	cmd = exec.CommandContext(ctx, h.Path, "workspace", "delete", "-no-color", name) //nolint:gosec
 	cmd.Dir = h.Dir
 
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
 	_, err = cmd.Output()
 	if err == nil {
 		// We successfully deleted the workspace; we're done.
@@ -367,6 +370,8 @@ func (h Harness) Outputs(ctx context.Context) ([]Output, error) {
 
 	outputs := map[string]output{}
 
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
 	out, err := cmd.Output()
 	if jerr := json.Unmarshal(out, &outputs); jerr != nil {
 		// If stdout doesn't appear to be the JSON we expected we try to extract
@@ -411,6 +416,8 @@ func (h Harness) Resources(ctx context.Context) ([]string, error) {
 	cmd := exec.CommandContext(ctx, h.Path, "state", "list") //nolint:gosec
 	cmd.Dir = h.Dir
 
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, Classify(err)
@@ -489,6 +496,9 @@ func (h Harness) Diff(ctx context.Context, o ...Option) (bool, error) {
 	cmd := exec.CommandContext(ctx, h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
+
 	// The -detailed-exitcode flag will make terraform plan return:
 	// 0 - Succeeded, diff is empty (no changes)
 	// 1 - Errored
@@ -517,6 +527,8 @@ func (h Harness) Apply(ctx context.Context, o ...Option) error {
 	cmd := exec.CommandContext(ctx, h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
 	_, err := cmd.Output()
 	return Classify(err)
 }
@@ -538,6 +550,8 @@ func (h Harness) Destroy(ctx context.Context, o ...Option) error {
 	cmd := exec.CommandContext(ctx, h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 
+	rwmutex.RLock()
+	defer rwmutex.RUnlock()
 	_, err := cmd.Output()
 	return Classify(err)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Replaced the semaphore in the internal terraform harness with a RWMutex.  RWMutex protects the terraform shared cache from corruption. If an init is performed, it requires a write lock. Only one write lock at a time. If another action is performed, a read lock is acquired. More than one read locks can be acquired. This prevents an init from inadvertently changing a plugin while it's in use. Prevents issues with `text file busy` errors. This is required if using max-reconcile-rate greater than 1.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Terraform Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #186 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I've tested the code locally with a max reconcile rate of 4.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
