### PR TITLE
feat: Supporting management policies beta feature

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -58,6 +58,7 @@ func main() {
 		maxReconcileRate           = app.Flag("max-reconcile-rate", "The maximum number of concurrent reconciliation operations.").Default("1").Int()
 		namespace                  = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
 		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
+		enableManagementPolicies   = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -107,6 +108,11 @@ func main() {
 		PollInterval:            *pollInterval,
 		GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
 		Features:                &feature.Flags{},
+	}
+
+	if *enableManagementPolicies {
+		o.Features.Enable(features.EnableBetaManagementPolicies)
+		log.Info("Beta feature enabled", "flag", features.EnableBetaManagementPolicies)
 	}
 
 	if *enableExternalSecretStores {

--- a/internal/controller/features/features.go
+++ b/internal/controller/features/features.go
@@ -24,4 +24,9 @@ const (
 	// External Secret Stores. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
 	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
+
+	// EnableBetaManagementPolicies enables beta support for
+	// Management Policies. See the below design for more details.
+	// https://github.com/crossplane/crossplane/pull/3531
+	EnableBetaManagementPolicies feature.Flag = "EnableBetaManagementPolicies"
 )


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR enables the Beta feature [management policies](https://docs.crossplane.io/latest/concepts/managed-resources/#managementpolicies), following the same approach as the AWS provider.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

The tests were done manually, applying the following scenarios:
- Applying Workspace without management policies (management policy feature disabled)
- Applying Workspace management policy [Observe] only (management policy feature disabled)
- Applying Workspace management policy [Observe] only (management policy feature enabled)
