### PR TITLE
Catch signals when running terraform CLI commands

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -44,7 +44,7 @@ const (
 	errParse            = "cannot parse Terraform output"
 	errWriteVarFile     = "cannot write tfvars file"
 	errFmtInvalidConfig = "invalid Terraform configuration: found %d errors"
-	errRunCommand       = " shutdown while running terraform command"
+	errRunCommand       = "shutdown while running terraform command"
 	errSigTerm          = "error sending SIGTERM to child process"
 	errWaitTerm         = "error waiting for child process to terminate"
 
@@ -585,11 +585,11 @@ func runCommand(ctx context.Context, c *exec.Cmd) ([]byte, error) {
 		// SIGTERM to the running process and wait for either the command to finish or the process to get killed.
 		e := c.Process.Signal(syscall.SIGTERM)
 		if e != nil {
-			return nil, errors.Wrap(errors.Wrap(e, errSigTerm), err.Error()+errRunCommand)
+			return nil, errors.Wrap(errors.Wrap(err, errRunCommand), errors.Wrap(e, errSigTerm).Error())
 		}
 		e = c.Wait()
 		if e != nil {
-			return nil, errors.Wrap(errors.Wrap(err, errWaitTerm), err.Error()+errRunCommand)
+			return nil, errors.Wrap(errors.Wrap(err, errRunCommand), errors.Wrap(e, errWaitTerm).Error())
 		}
 		return nil, errors.Wrap(err, errRunCommand)
 	case res := <-ch:


### PR DESCRIPTION
### Description of your changes
This change executes the terraform CLI command inside a wrapper that will terminate the CLI command if the context terminates via timeout or signal before the command finishes.

This will help with handling provider shutdown cleanly but it may also leave the Workspace in an unknown state if the running command was `apply` or `destroy`.

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

This code needs to soak in a test environment for a while but I wanted to get the changes reviewed in the mean time.  I'll take the PR out of WIP when the changes have been tested locally.

Test procedure:
- Create a Workspace that has a terraform time_sleep resource with create_timeout set to 5 minutes and uses the terraform kubernetes backend
- While tailing the pod log apply the workspace and observe that the reconcile of the workspace starts
- Retrieve the list of kubernetes lease resources and observe that there is a lease for the specified workspace
- Terminate the provider pod and observe in the logs that the process gets terminated. Observe that the Lease for the workspace has been deleted.
