### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,23 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommits"
   ],
-// The maximum number of PRs to be created in parallel
+  // We only want renovate to rebase PRs when they have conflicts,
+  // default "auto" mode is not required.
+  "rebaseWhen": "conflicted",
+  // The maximum number of PRs to be created in parallel
   "prConcurrentLimit": 5,
-// The branches renovate should target
+  // The branches renovate should target
   "baseBranches": ["main"],
   "ignorePaths": ["design/**"],
   "postUpdateOptions": ["gomodTidy"],
-// By default renovate will auto detect whether semantic commits have been used
-// in the recent history and comply with that, we explicitly disable it
-  "semanticCommits": "disabled",
-// All PRs should have a label
+  // All PRs should have a label
   "labels": ["automated"],
-  "regexManagers": [
+  "customManagers": [
     {
-// We want a PR to bump Go versions used through env variables in any Github
-// Actions, taking it from the official Github repository.
+      "customType": "regex",
+      "description": "Bump Go version used in workflows",
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": [
         "GO_VERSION: '(?<currentValue>.*?)'\\n"
@@ -25,115 +27,87 @@
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang"
     }, {
-// We want a PR to bump golangci-lint versions used through env variables in
-// any Github Actions, taking it from the official Github repository tags.
-      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "customType": "regex",
+      "description": "Bump golangci-lint version in workflows and the Makefile",
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$","^Makefile$"],
       "matchStrings": [
-        "GOLANGCI_VERSION: '(?<currentValue>.*?)'\\n"
+        "GOLANGCI_VERSION: 'v(?<currentValue>.*?)'\\n",
+        "GOLANGCILINT_VERSION = (?<currentValue>.*?)\\n"
       ],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "golangci/golangci-lint"
+      "depNameTemplate": "golangci/golangci-lint",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }, {
+      "customType": "regex",
+      "description": "Bump helm version in the Makefile",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "HELM3_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "helm/helm",
+    }, {
+      "customType": "regex",
+      "description": "Bump kind version in the Makefile",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "KIND_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "kubernetes-sigs/kind",
     }
   ],
-// PackageRules disabled below should be enabled in case of vulnerabilities
+  // PackageRules disabled below should be enabled in case of vulnerabilities
   "vulnerabilityAlerts": {
     "enabled": true
   },
+  "osvVulnerabilityAlerts": true,
+  // Renovate evaluates all packageRules in order, so low priority rules should
+  // be at the beginning, high priority at the end
   "packageRules": [
     {
-// We need to ignore k8s.io/client-go older versions as they switched to
-// semantic version and old tags are still available in the repo.
+      "description": "Only get Docker image updates every 2 weeks to reduce noise",
+      "matchDatasources": ["docker"],
+      "schedule": ["every 2 week on monday"],
+      enabled: true,
+    }, {
+      "description": "Ignore k8s.io/client-go older versions, they switched to semantic version and old tags are still available in the repo",
       "matchDatasources": [
         "go"
       ],
       "matchDepNames": [
         "k8s.io/client-go"
       ],
-      "allowedVersions": "<1.0"
+      "allowedVersions": "<1.0",
     }, {
-// We want a single PR for all the patches bumps of kubernetes related
-// dependencies, as most of the times these are all strictly related.
+      "description": "Ignore k8s dependencies, should be updated on crossplane-runtime",
       "matchDatasources": [
         "go"
-      ],
-      "groupName": "kubernetes patches",
-      "matchUpdateTypes": [
-        "patch",
-        "digest"
       ],
       "matchPackagePrefixes": [
         "k8s.io",
         "sigs.k8s.io"
-      ]
-    }, {
-// We want dedicated PRs for each minor and major bumps to kubernetes related
-// dependencies.
-      "matchDatasources": [
-        "go"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "matchPackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ]
-    }, {
-// We want dedicated PRs for each bump to non-kubernetes Go dependencies, but
-// only if there are known vulnerabilities in the current version.
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackagePatterns": [
-        "*"
       ],
       "enabled": false,
-      "excludePackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ],
-      "matchUpdateTypes": [
-        "major",
-      ],
-    }, {
-// We want a single PR for all minor and patch bumps to non-kubernetes Go
-// dependencies, but only if there are known vulnerabilities in the current
-// version.
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "enabled": false,
-      "excludePackagePrefixes": [
-        "k8s.io",
-        "sigs.k8s.io"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest"
-      ],
-      "groupName": "all non-major go dependencies"
-    }, {
-// We want a single PR for all minor and patch bumps of Github Actions
-      "matchDepTypes": [
-        "action"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all non-major github action",
-      "pinDigests": true
     },{
-// We want dedicated PRs for each major bump to Github Actions
+      "description": "Only get dependency digest updates every month to reduce noise, except crossplane-runtime",
+      "excludePackageNames": ["github.com/crossplane/crossplane-runtime"],
+      "matchDatasources": [
+        "go"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+      ],
+      "extends": ["schedule:monthly"],
+    }, {
+      "description": "Ignore oss-fuzz, it's not using tags, we'll stick to master",
       "matchDepTypes": [
         "action"
       ],
-      "pinDigests": true
+      "matchDepNames": [
+        "google/oss-fuzz"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
### Description of your changes
Update renovate config to more closely align with crossplane.

Mostly this means that the k8s dependencies will be left to crossplane-runtime to update.

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
A test run should be triggered based on the name of the branch, at least according to this:  https://github.com/renovatebot/renovate/discussions/25604#discussioncomment-7486250

If it doesn't trigger based on the PR I can push the branch directly to the repo and see if that triggers it.
