### PR TITLE
Make the terraform harness only use the rwmutex if the plugin cache is enabled

### DIFF
--- a/internal/controller/workspace/workspace_test.go
+++ b/internal/controller/workspace/workspace_test.go
@@ -68,7 +68,7 @@ func (e *ErrFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, e
 }
 
 type MockTf struct {
-	MockInit                   func(ctx context.Context, cache bool, o ...terraform.InitOption) error
+	MockInit                   func(ctx context.Context, o ...terraform.InitOption) error
 	MockWorkspace              func(ctx context.Context, name string) error
 	MockOutputs                func(ctx context.Context) ([]terraform.Output, error)
 	MockResources              func(ctx context.Context) ([]string, error)
@@ -79,8 +79,8 @@ type MockTf struct {
 	MockGenerateChecksum       func(ctx context.Context) (string, error)
 }
 
-func (tf *MockTf) Init(ctx context.Context, cache bool, o ...terraform.InitOption) error {
-	return tf.MockInit(ctx, cache, o...)
+func (tf *MockTf) Init(ctx context.Context, o ...terraform.InitOption) error {
+	return tf.MockInit(ctx, o...)
 }
 
 func (tf *MockTf) GenerateChecksum(ctx context.Context) (string, error) {
@@ -124,7 +124,7 @@ func TestConnect(t *testing.T) {
 		kube      client.Client
 		usage     resource.Tracker
 		fs        afero.Afero
-		terraform func(dir string) tfclient
+		terraform func(dir string, usePluginCache bool) tfclient
 	}
 
 	type args struct {
@@ -216,9 +216,9 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 					}
 				},
 			},
@@ -255,9 +255,9 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfCreds): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 					}
 				},
 			},
@@ -294,9 +294,9 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), "subdir", tfCreds): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 					}
 				},
 			},
@@ -338,9 +338,9 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join("/tmp", tfDir, string(uid), ".git-credentials"): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 					}
 				},
 			},
@@ -381,9 +381,9 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join("/tmp", tfDir, string(uid)): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 					}
 				},
 			},
@@ -422,9 +422,9 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfConfig): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 					}
 				},
 			},
@@ -463,9 +463,9 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), "subdir", tfConfig): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 					}
 				},
 			},
@@ -499,9 +499,9 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfMain): errBoom},
 					},
 				},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 					}
 				},
 			},
@@ -529,8 +529,8 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
-					return &MockTf{MockInit: func(_ context.Context, cache bool, _ ...terraform.InitOption) error { return errBoom }}
+				terraform: func(_ string, _ bool) tfclient {
+					return &MockTf{MockInit: func(_ context.Context, _ ...terraform.InitOption) error { return errBoom }}
 				},
 			},
 			args: args{
@@ -553,9 +553,9 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit:      func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit:      func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 						MockWorkspace: func(_ context.Context, _ string) error { return errBoom },
 					}
 				},
@@ -579,7 +579,7 @@ func TestConnect(t *testing.T) {
 			},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
 						MockGenerateChecksum: func(ctx context.Context) (string, error) { return "", errBoom },
 					}
@@ -613,7 +613,7 @@ func TestConnect(t *testing.T) {
 			},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
 						MockGenerateChecksum: func(ctx context.Context) (string, error) { return tfChecksum, nil },
 						MockWorkspace:        func(_ context.Context, _ string) error { return nil },
@@ -649,9 +649,9 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit:             func(ctx context.Context, cache bool, o ...terraform.InitOption) error { return nil },
+						MockInit:             func(ctx context.Context, o ...terraform.InitOption) error { return nil },
 						MockGenerateChecksum: func(ctx context.Context) (string, error) { return tfChecksum, nil },
 						MockWorkspace:        func(_ context.Context, _ string) error { return nil },
 					}
@@ -688,9 +688,9 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
-				terraform: func(_ string) tfclient {
+				terraform: func(_ string, _ bool) tfclient {
 					return &MockTf{
-						MockInit: func(ctx context.Context, cache bool, o ...terraform.InitOption) error {
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error {
 							args := terraform.InitArgsToString(o)
 							if len(args) != 2 {
 								return errors.New("two init args are expected")

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -524,10 +524,8 @@ func (h Harness) Diff(ctx context.Context, o ...Option) (bool, error) {
 	cmd := exec.Command(h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 
-	if h.UsePluginCache {
-		rwmutex.RLock()
-		defer rwmutex.RUnlock()
-	}
+	// Note: the rwmutex is intentionally not locked here to avoid excessive blocking. See
+	// https://github.com/upbound/provider-terraform/issues/239#issuecomment-1921732682
 
 	// The -detailed-exitcode flag will make terraform plan return:
 	// 0 - Succeeded, diff is empty (no changes)

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -524,7 +524,8 @@ func (h Harness) Diff(ctx context.Context, o ...Option) (bool, error) {
 	cmd := exec.Command(h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 
-	// Note: the rwmutex is intentionally not locked here to avoid excessive blocking. See
+	// Note: the terraform lock is not used (see the -lock=false flag above) and the rwmutex is
+	// intentionally not locked here to avoid excessive blocking. See
 	// https://github.com/upbound/provider-terraform/issues/239#issuecomment-1921732682
 
 	// The -detailed-exitcode flag will make terraform plan return:

--- a/internal/terraform/terraform_harness_test.go
+++ b/internal/terraform/terraform_harness_test.go
@@ -439,9 +439,9 @@ func TestInitDiffApplyDestroy(t *testing.T) {
 			}
 			defer os.RemoveAll(dir)
 
-			tf := Harness{Path: tfBinaryPath, Dir: dir}
+			tf := Harness{Path: tfBinaryPath, Dir: dir, UsePluginCache: false}
 
-			err = tf.Init(tc.initArgs.ctx, false, tc.initArgs.o...)
+			err = tf.Init(tc.initArgs.ctx, tc.initArgs.o...)
 			if diff := cmp.Diff(tc.want.init, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ntf.Init(...): -want error, +got error:\n%s", tc.reason, diff)
 			}


### PR DESCRIPTION
### Description of your changes

As discussed in #239, this makes the terraform harness only take the lock if the plugin cache is enabled. If the plugin cache is not enabled, there is nothing to protect, and thus no need to take the lock.

This change also removes locking for all `terraform plan` operations, on the assumption that conflicts are unlikely, and can easily be retried on a subsequent reconcile if they do happen.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review. It returned a bunch of type errors which seemed unrelated to this change, but I ran `make test` which did pass and `make build` which did succeed.

### How has this code been tested

Unit tests
