### PR TITLE
Move SYNCED before READY in output

### DIFF
--- a/apis/v1beta1/workspace_types.go
+++ b/apis/v1beta1/workspace_types.go
@@ -155,8 +155,8 @@ type WorkspaceStatus struct {
 
 // A Workspace of Terraform Configuration.
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,terraform}
 type Workspace struct {

--- a/package/crds/tf.upbound.io_workspaces.yaml
+++ b/package/crds/tf.upbound.io_workspaces.yaml
@@ -19,11 +19,11 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: READY
-      type: string
     - jsonPath: .status.conditions[?(@.type=='Synced')].status
       name: SYNCED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE


### PR DESCRIPTION
### Description of your changes

This change swaps the SYNCED and READY columns in the `kubectl get workspace` output so that they read left-to-right in the order that you would expect them to occur.  This brings the output in line with provider-kubernetes `Objects` and provider-helm `Releases`.

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Tested the updated CRDs and verified that the columns are swapped.