### PR TITLE
fix(ess): missing mtls injection

### DIFF
--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -122,7 +122,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout, pollJitter time.Dura
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {
-		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), v1beta1.StoreConfigGroupVersionKind))
+		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), v1beta1.StoreConfigGroupVersionKind, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))
 	}
 
 	c := &connector{
@@ -355,7 +355,6 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 	// Include any non-sensitive outputs in our status
 	op, err := c.tf.Outputs(ctx)
-
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, errOutputs)
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Missing Tls injection when `--enable-secrets-store` 
the error message regading the issue  message disapears
![20240303_00h18m16s_grim](https://github.com/upbound/provider-terraform/assets/26741817/795cdad5-e669-4f59-807f-8a807f420794)

Fixes #228

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
this code as been tested has this 


```shell
$ export CROSSPLANE_ARGS="--enable-external-secret-stores"
$ export CROSSPLANE_NAMESPACE=crossplane-system
$ make local-deploy
```
```yaml
# Edit `controllerConfig` according to doc in Kind cluster dev made available by `make local-dev`
apiVersion: pkg.crossplane.io/v1alpha1
kind: ControllerConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"pkg.crossplane.io/v1alpha1","kind":"ControllerConfig","metadata":{"annotations":{},"name":"config-provider-terraform"},"spec":{"args":["-d"],"image":"build-aa89c30c/provider-terraform-amd64"}}
  creationTimestamp: "2024-03-02T17:49:25Z"
  generation: 5
  name: config-provider-terraform
  resourceVersion: "3936"
  uid: 2649d006-c0e6-4020-ae0d-edb5ab719fab
spec:
  args:
  - -d
  - --enable-external-secret-stores
  image: build-aa89c30c/provider-terraform-amd64
  metadata:
    annotations:
      vault.hashicorp.com/agent-inject: "true"
      vault.hashicorp.com/agent-inject-token: "true"
      vault.hashicorp.com/agent-run-as-user: "2000"
      vault.hashicorp.com/role: crossplane
```
# then install as the doc says 
=> https://docs.crossplane.io/knowledge-base/integrations/vault-as-secret-store/#add-the-vault-helm-chart


then use the example giva in configuration marketplace terraform-provider
==>https://marketplace.upbound.io/providers/upbound/provider-terraform/v0.14.1/docs/configuration
```yaml
---
apiVersion: tf.upbound.io/v1beta1
kind: StoreConfig
metadata:
  name: vault
spec:
  type: Vault
  defaultScope: crossplane-system
  vault:
    server: http://vault.vault-system:8200
    mountPath: secret/
    version: v2
    auth:
      method: Token
      token:
        source: Filesystem
        fs:
          path: /vault/secrets/token
---
apiVersion: tf.upbound.io/v1beta1
kind: Workspace
metadata:
  name: example-random-generator
  annotations:
    meta.upbound.io/example-id: tf/v1beta1/workspace
    # The terraform workspace will be named 'random'. If you omit this
    # annotation it would be derived from metadata.name - e.g. 'example-random-generator.
    # crossplane.io/external-name: crossplane
spec:
  forProvider:
    source: Inline
    module: |
      resource "random_id" "example_id" {
        byte_length = 8
      }
      resource "random_password" "password" {
        length = 16
        special = true
      }
      // Non-sensitive Outputs are written to status.atProvider.outputs and to the connection secret.
      output "random_id_hex" {
        value       = random_id.example_id.hex
      }
      // Sensitive Outputs are only written to the connection secret
      output "random_password" {
        value = random_password.password
        sensitive = true
      }
      // Terraform has several other random resources, see the random provider for details
  providerConfigRef:
    name: ess-terraform
  publishConnectionDetailsTo:
    name: random-to-vault
    configRef:
      name: vault

  writeConnectionSecretToRef:
    namespace: vault-system
    name: terraform-workspace-example-random-generator
```
