### PR TITLE
Disable the client cache for Workspace lookups

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -85,6 +86,16 @@ func main() {
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		Cache: cache.Options{
 			SyncPeriod: syncInterval,
+		},
+
+		// TODO(slittley): Remove this when kubernetes/kubernetes#112328 or kubernetes/kubernetes#123071
+		// is merged and propagated through the chain of dependencies.
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&v1beta1.Workspace{},
+				},
+			},
 		},
 
 		// controller-runtime uses both ConfigMaps and Leases for leader


### PR DESCRIPTION
### Description of your changes

Fixes #243 (sort of)

This disables the cache used when getting Workspace resources at the start of each reconciliation to avoid a potential concurrent map iteration/write, caused by the client-go workqueue not being fully deduplicated. That's an upstream bug, for which this PR is a mitigation to prevent the provider crashing.

I'm not totally convinced that this is the right thing to do. If we are actually seeing concurrent reconciliations of the same workspace, maybe it is better to crash; the problem is that crashing has the potential to leave workspaces in an inconsistent state (i.e. half-applied, with the state lock left around), and causes all workspaces to be reconciled at once when the provider starts back up.

If we do see concurrent reconciles, we should still be protected by the terraform state lock, although we might see strange errors/status on the resource.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Unit tests passed; I intend to rely on the Github Action integration test to assert that the provider still works as intended, but the actual bug happens very rarely (With 100+ Workspaces we saw provider-terraform go 10 days without crashing) so it's hard to prove that this fixes the issue.
