### PR TITLE
Ability to override terraform version per Workspace with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ spec:
           namespace: my-namespace
           name: my-secret
           key: target-key
+      - name: TFENV_TERRAFORM_VERSION # Override default terraform version for this Workspace
+        value: 1.4.0
     # Variables can be specified inline as a list of key-value pairs or as an json object, or loaded from a ConfigMap or Secret.
     vars:
     - key: region

--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 ENV TENV_VERSION=1.5.0
-ENV TERRAFORM_VERSION=1.5.5
+ENV TFENV_TERRAFORM_DEFAULT_VERSION=1.5.5
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
 
@@ -17,10 +17,10 @@ ADD .gitconfig .gitconfig
 RUN wget https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_amd64.apk \
   && apk add --allow-untrusted tenv_v${TENV_VERSION}_amd64.apk \
   && rm tenv_v${TENV_VERSION}_amd64.apk \
-  && tenv tf use ${TERRAFORM_VERSION} \
   && mkdir -p ${TF_PLUGIN_CACHE_DIR} \
   && mkdir -p /.tenv \
-  && chown -R 2000 /tf /.tenv/
+  && chown -R 2000 /tf /.tenv/ \
+  && tenv tf use ${TFENV_TERRAFORM_DEFAULT_VERSION}
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
 

--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -3,6 +3,7 @@ RUN apk --no-cache add ca-certificates bash git curl
 ARG TARGETOS
 ARG TARGETARCH
 
+ENV TENV_VERSION=1.5.0
 ENV TERRAFORM_VERSION=1.5.5
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
@@ -13,10 +14,10 @@ ADD .gitconfig .gitconfig
 # Do not change the URL from which the Terraform CLI is downloaded.
 # We are using an MPL-2.0 licensed version of the CLI and
 # we must make sure that this holds true.
-RUN curl -s -L https://github.com/upbound/terraform/releases/download/v${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip -o terraform.zip \
-  && unzip -d /usr/local/bin terraform.zip \
-  && rm terraform.zip \
-  && chmod +x /usr/local/bin/terraform \
+RUN wget https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_amd64.apk \
+  && apk add --allow-untrusted tenv_v${TENV_VERSION}_amd64.apk \
+  && rm tenv_v${TENV_VERSION}_amd64.apk \
+  && tenv tf use ${TERRAFORM_VERSION} \
   && mkdir -p ${TF_PLUGIN_CACHE_DIR} \
   && chown -R 2000 /tf
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.

--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -19,7 +19,8 @@ RUN wget https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/te
   && rm tenv_v${TENV_VERSION}_amd64.apk \
   && tenv tf use ${TERRAFORM_VERSION} \
   && mkdir -p ${TF_PLUGIN_CACHE_DIR} \
-  && chown -R 2000 /tf
+  && mkdir -p /.tenv \
+  && chown -R 2000 /tf /.tenv/
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
 

--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -19,9 +19,8 @@ RUN wget https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/te
   && apk add --allow-untrusted tenv_v${TENV_VERSION}_amd64.apk \
   && rm tenv_v${TENV_VERSION}_amd64.apk \
   && mkdir -p ${TF_PLUGIN_CACHE_DIR} \
-  && mkdir -p /.tenv \
-  && chown -R 2000 /tf /.tenv/ \
-  && tenv tf install ${TFENV_TERRAFORM_DEFAULT_VERSION}
+  && tenv tf install ${TFENV_TERRAFORM_DEFAULT_VERSION} \
+  && chown -R 2000 /tf /.tenv/
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
 

--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -4,6 +4,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 ENV TENV_VERSION=1.5.0
+ENV TENV_ROOT=/.tenv
 ENV TFENV_TERRAFORM_DEFAULT_VERSION=1.5.5
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
@@ -20,7 +21,7 @@ RUN wget https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/te
   && mkdir -p ${TF_PLUGIN_CACHE_DIR} \
   && mkdir -p /.tenv \
   && chown -R 2000 /tf /.tenv/ \
-  && tenv tf use ${TFENV_TERRAFORM_DEFAULT_VERSION}
+  && tenv tf install ${TFENV_TERRAFORM_DEFAULT_VERSION}
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -355,3 +355,22 @@ spec:
 At Vault side configuration is also needed to allow the write operation, see
 [example](https://docs.crossplane.io/knowledge-base/integrations/vault-as-secret-store/)
 here for inspiration.
+
+## Custom Terraform CLI version
+
+To customize the terraform version per workspace simply declare the special
+environment variable:
+
+```yaml
+apiVersion: tf.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  name: sample-inline-own-tf-version
+spec:
+  forProvider:
+    source: Inline
+    env:
+      - name: TFENV_TERRAFORM_VERSION
+        value: 1.4.0 # Custom version for this Workspace
+...
+```

--- a/examples/workspace-inline-aws-bring-your-own-terraform.yaml
+++ b/examples/workspace-inline-aws-bring-your-own-terraform.yaml
@@ -1,0 +1,37 @@
+apiVersion: tf.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  name: sample-inline-own-tf-version
+spec:
+  forProvider:
+    source: Inline
+    env:
+      - name: TFENV_TERRAFORM_VERSION
+        value: 1.4.0
+    module: |
+      resource "aws_vpc" "main" {
+        cidr_block       = "10.0.0.0/16"
+        tags = {
+          Name = var.vpcName
+        }
+      }
+      resource "aws_subnet" "main" {
+        vpc_id     = aws_vpc.main.id
+        cidr_block = "10.0.1.0/24"
+      }
+      output "vpc_id" {
+        value       = aws_vpc.main.id
+      }
+      output "subnet_data" {
+        value = {
+          "id" = aws_subnet.main.id
+          "arn" = aws_subnet.main.arn
+        }
+      }
+      variable "vpcName" {
+        description = "VPC name"
+        type        = string
+      }
+    vars:
+      - key: vpcName
+        value: sample-tf-inline


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Terraform Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

* Inspired by  https://github.com/upbound/provider-terraform/pull/82 CC @bdwyertech 
* Add https://github.com/tofuutils/tenv/ to the provider image, a Golang-based successor to https://github.com/tfutils/tfenv
* Manage the terraform cli version with it, default to the current 'safe' 1.5.5 
* Document usage
* Overriding the custom version of terraform per Workspace is as easy as
```
    env:
      - name: TFENV_TERRAFORM_VERSION
        value: 1.4.0 #custom version per workspace
```
the tenv will handle the installation and invocation of the custom version

* Within provider pod the multiple version are stored in `/.tenv` and looks like this in case of multiple version usage
```
~ $ cd .tenv/
/.tenv $ tree
.
└── Terraform
    ├── 1.4.0
    │   └── terraform
    ├── 1.5.5
    │   └── terraform
```

* `/.tenv/Terraform/1.5.5/` is the current default version and prepackaged to the provider image

Fixes #84 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Running custom provider image with this change and invoking several workspace examples

```
k get workspaces.tf.upbound.io
NAME                           SYNCED   READY   AGE
sample-inline-with-env         True     True    26m
sample-inline-own-tf-version   True     True    19m
```

Checked the associated contents of `/.tenv` directory and custom terraform cli invocation in the process list  - it worked as expected.
