### PR TITLE
feat: introduce json format for inline module (#165)

### DIFF
--- a/apis/v1beta1/workspace_types.go
+++ b/apis/v1beta1/workspace_types.go
@@ -39,14 +39,14 @@ const (
 	VarFileSourceSecretKey    VarFileSource = "SecretKey"
 )
 
-// A VarFileFormat specifies the format of a Terraform vars file.
+// A FileFormat specifies the format of a Terraform file.
 // +kubebuilder:validation:Enum=HCL;JSON
-type VarFileFormat string
+type FileFormat string
 
 // Vars file formats.
 var (
-	VarFileFormatHCL  VarFileFormat = "HCL"
-	VarFileFormatJSON VarFileFormat = "JSON"
+	FileFormatHCL  FileFormat = "HCL"
+	FileFormatJSON FileFormat = "JSON"
 )
 
 // A VarFile is a file containing many Terraform variables.
@@ -57,7 +57,7 @@ type VarFile struct {
 	// Format of this vars file.
 	// +kubebuilder:default=HCL
 	// +optional
-	Format *VarFileFormat `json:"format,omitempty"`
+	Format *FileFormat `json:"format,omitempty"`
 
 	// A ConfigMap key containing the vars file.
 	// +optional
@@ -108,8 +108,12 @@ type WorkspaceParameters struct {
 	// file. When the workspace's source is 'Remote' (the default) this can be
 	// any address supported by terraform init -from-module, for example a git
 	// repository or an S3 bucket. When the workspace's source is 'Inline' the
-	// content of a simple main.tf file may be written inline.
+	// content of a simple main.tf or main.tf.json file may be written inline.
 	Module string `json:"module"`
+
+	// Specifies the format of the inline Terraform content
+	// if Source is 'Inline'
+	InlineFormat FileFormat `json:"inlineFormat,omitempty"`
 
 	// Source of the root module of this workspace.
 	Source ModuleSource `json:"source"`

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -362,7 +362,7 @@ func (in *VarFile) DeepCopyInto(out *VarFile) {
 	*out = *in
 	if in.Format != nil {
 		in, out := &in.Format, &out.Format
-		*out = new(VarFileFormat)
+		*out = new(FileFormat)
 		**out = **in
 	}
 	if in.ConfigMapKeyReference != nil {

--- a/package/crds/tf.upbound.io_workspaces.yaml
+++ b/package/crds/tf.upbound.io_workspaces.yaml
@@ -143,13 +143,21 @@ spec:
                     items:
                       type: string
                     type: array
+                  inlineFormat:
+                    description: |-
+                      Specifies the format of the inline Terraform content
+                      if Source is 'Inline'
+                    enum:
+                    - HCL
+                    - JSON
+                    type: string
                   module:
                     description: |-
                       The root module of this workspace; i.e. the module containing its main.tf
                       file. When the workspace's source is 'Remote' (the default) this can be
                       any address supported by terraform init -from-module, for example a git
                       repository or an S3 bucket. When the workspace's source is 'Inline' the
-                      content of a simple main.tf file may be written inline.
+                      content of a simple main.tf or main.tf.json file may be written inline.
                     type: string
                   planArgs:
                     description: Arguments to be included in the terraform plan CLI


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
**API Change:**
Added a new property `InlineFormat` to `WorkspaceParameters` which specifies the format of the inline Terraform content. It could be `HCL` or `JSON`

**Change:**
If `InlineFormat` is set to `JSON` the file which is created is named `main.tf.json` instead of `main.tf` 

Fixes #165

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Wrote a UnitTest and already tested it in my environment
