### PR TITLE
Scalability by workspace sharding

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -64,6 +64,7 @@ func main() {
 		namespace                  = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
 		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
 		enableManagementPolicies   = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
+		enableWorkspaceSharding    = app.Flag("enable-workspace-sharding", "Enable support for Workspace Sharding.").Default("false").Envar("ENABLE_WORKSPACE_SHARDING").Bool()
 		essTLSCertsPath            = app.Flag("ess-tls-cert-dir", "Path of ESS TLS certificates.").Envar("ESS_TLS_CERTS_DIR").String()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -127,6 +128,11 @@ func main() {
 	if *enableManagementPolicies {
 		o.Features.Enable(features.EnableBetaManagementPolicies)
 		log.Info("Beta feature enabled", "flag", features.EnableBetaManagementPolicies)
+	}
+
+	if *enableWorkspaceSharding {
+		o.Features.Enable(features.EnableAlphaWorkspaceSharding)
+		log.Info("Alpha feature enabled", "flag", features.EnableAlphaWorkspaceSharding)
 	}
 
 	if *enableExternalSecretStores {

--- a/internal/controller/features/features.go
+++ b/internal/controller/features/features.go
@@ -25,6 +25,9 @@ const (
 	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
 	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
 
+	// EnableAlphaWorkspaceSharding enables alpha support for workspace sharding.
+	EnableAlphaWorkspaceSharding feature.Flag = "EnableAlphaWorkspaceSharding"
+
 	// EnableBetaManagementPolicies enables beta support for
 	// Management Policies. See the below design for more details.
 	// https://github.com/crossplane/crossplane/pull/3531

--- a/internal/controller/identity/identity.go
+++ b/internal/controller/identity/identity.go
@@ -1,0 +1,182 @@
+package identity
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/pkg/errors"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Error strings.
+const (
+	errAddInformerToManager         = "cannot add informer factory to manager"
+	errDeploymentEnvVarsNotSet      = "POD_NAMESPACE or POD_NAME environment variable is not set"
+	errGetCurrentPod                = "cannot get current pod"
+	errInitKubernetesInformerClient = "cannot init Kubernetes informer client"
+	errListPods                     = "cannot list pods"
+	errSetupPodInformer             = "cannot setup Pod informer"
+	errSetupReplicaSetInformer      = "cannot setup ReplicaSet informer"
+)
+
+// Label strings.
+const (
+	labelCrossplanePackageRevision = "pkg.crossplane.io/revision"
+)
+
+var logger logging.Logger
+
+type Identity interface {
+	GetIndex() int
+	GetReplicas() int
+}
+
+type IdentityHolder struct {
+	index    int
+	replicas int
+}
+
+func (i *IdentityHolder) GetIndex() int {
+	return i.index
+}
+
+func (i *IdentityHolder) GetReplicas() int {
+	return i.replicas
+}
+
+func Setup(mgr ctrl.Manager, o controller.Options) (Identity, error) {
+	logger = o.Logger
+
+	identity := &IdentityHolder{
+		index:    -1,
+		replicas: -1,
+	}
+
+	namespace := strings.TrimSpace(os.Getenv("POD_NAMESPACE"))
+	podName := strings.TrimSpace(os.Getenv("POD_NAME"))
+	if namespace == "" || podName == "" {
+		return nil, errors.New(errDeploymentEnvVarsNotSet)
+	}
+
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return nil, errors.Wrap(err, errInitKubernetesInformerClient)
+	}
+
+	rsName := ""
+	if pod, err := clientset.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{}); err != nil {
+		return nil, errors.Wrap(err, errGetCurrentPod)
+	} else {
+		rsName = pod.OwnerReferences[0].Name
+	}
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, informers.WithNamespace(namespace))
+	if err := setupReplicaSetInformer(informerFactory, identity, rsName); err != nil {
+		return nil, errors.Wrap(err, errSetupReplicaSetInformer)
+	}
+	if err := setupPodInformer(informerFactory, identity, rsName, podName); err != nil {
+		return nil, errors.Wrap(err, errSetupPodInformer)
+	}
+
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		logger.Debug("Starting informers")
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+
+		<-ctx.Done()
+		logger.Debug("Stopping informers")
+		return nil
+	})); err != nil {
+		return nil, errors.Wrap(err, errAddInformerToManager)
+	}
+
+	return identity, nil
+}
+
+func setupReplicaSetInformer(informerFactory informers.SharedInformerFactory, identityHolder *IdentityHolder, rsName string) error {
+	_, err := informerFactory.Apps().V1().ReplicaSets().Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: replicaSetFilterFunc(rsName),
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: replicaSetHandlerFunc(identityHolder),
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				replicaSetHandlerFunc(identityHolder)(newObj)
+			},
+		},
+	})
+	return err
+}
+
+func replicaSetFilterFunc(rsName string) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		return obj.(*appsv1.ReplicaSet).GetName() == rsName
+	}
+}
+
+func replicaSetHandlerFunc(identityHolder *IdentityHolder) func(obj interface{}) {
+	return func(obj interface{}) {
+		identityHolder.replicas = int(*obj.(*appsv1.ReplicaSet).Spec.Replicas)
+		logger.Debug("Replicas value updated", "replicas", identityHolder.replicas)
+	}
+}
+
+func setupPodInformer(informerFactory informers.SharedInformerFactory, identityHolder *IdentityHolder, rsName string, podName string) error {
+	_, err := informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: podFilterFunc(rsName),
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    podHandlerFunc(informerFactory, identityHolder, podName),
+			DeleteFunc: podHandlerFunc(informerFactory, identityHolder, podName),
+		},
+	})
+	return err
+}
+
+func podFilterFunc(rsName string) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		for _, ownerRef := range obj.(*corev1.Pod).GetOwnerReferences() {
+			if ownerRef.Name == rsName {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func podHandlerFunc(informerFactory informers.SharedInformerFactory, identityHolder *IdentityHolder, podName string) func(obj interface{}) {
+	return func(obj interface{}) {
+		identityHolder.index = -1
+
+		pods, err := informerFactory.Core().V1().Pods().Lister().
+			List(labels.Set{labelCrossplanePackageRevision: obj.(*corev1.Pod).GetLabels()[labelCrossplanePackageRevision]}.AsSelector())
+		if err != nil {
+			logger.Info(errListPods, "error", err)
+			return
+		}
+
+		sort.Slice(pods, func(i, j int) bool {
+			return pods[i].Name < pods[j].Name
+		})
+		for i, pod := range pods {
+			if pod.Name == podName {
+				identityHolder.index = i
+				break
+			}
+		}
+
+		logger.Debug("Index value updated", "index", identityHolder.index)
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,10 @@
+package utils
+
+import "hash/fnv"
+
+func HashAndModulo(str string, modulo int) int {
+	hasher := fnv.New32a()
+	hasher.Write([]byte(str))
+	hash := hasher.Sum32()
+	return int(hash) % modulo
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Terraform Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Terraform Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Terraform Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This pull request introduces a scalability enhancement to the terraform provider, enabling workspace and provider configuration sharding for better resource distribution and management in multi-replica environments. This feature significantly improves reconciliation speed and reduces the time taken to apply changes in large environments (e.g., 300+ workspaces).


Key features:

- Replica Indexing: The replica index is used to determine which resources are managed by a specific replica. This replica index is calculated dynamically when adding, updating or deleting pods in the replicaset.
- Modulo Operation for Sharding: The provider uses a modulo operation to filter resources according to the replica index and total number of replicas, ensuring even distribution of workloads.
- Workspace & Provider Config Sharding: In the reconciliation process, resources are now distributed across replicas based on a unique replica index.

The feature is disabled by default and can be activated by adding the `--enable-workspace-sharding` flag.


Limitations:

- To retrieve the replica index and total replica count, the provider queries the replicaset K8s resource, which requires read permissions (get, list and watch) on the pods and replicaset resources. This requires a specific role binding to be set up. Considering this, it's useful to set a specific service account name in the Deployment Runtime Config.
- The current replica need to know its pod name to determine its index in the replicaset. This can be done thanks to the valueFrom and fieldRef keywords in the Deployment Runtime Config.

This change enables faster performance in multi-replica environments, especially in large-scale use cases with numerous workspaces.


I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Updated the documentation: I will do it if you are interested by this feature.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

The code has been tested by using debug messages in real conditions to verify that the workspaces are correctly sharded to unique replicas. Additionally, I monitored the speed of the reconciliation process and observed that it performs faster, especially when handling large environments with multiple workspaces. This confirmed that the sharding mechanism effectively improves the speed of resource reconciliation.
