### PR TITLE
[release-0.19]: Update go version to 1.22.12 [SECURITY]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upbound/provider-terraform
 
-go 1.22.11
+go 1.22.12
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
### Description of your changes

This PR updates `go.mod` dependencies to fix the following:

| Name | Change | Type | Vulnerability | Severity |
|---|---|---|---|---|
| stdlib | `go1.22.11` -> `go1.22.12` | go-module | CVE-2025-22866 | - |

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
