### PR TITLE
Fix: provide environment variables when running `terraform workspace new`

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -264,6 +264,9 @@ func (h Harness) Workspace(ctx context.Context, name string) error {
 	// is somewhat optimistic, but it shouldn't hurt to try.
 	cmd = exec.Command(h.Path, "workspace", "new", "-no-color", name) //nolint:gosec
 	cmd.Dir = h.Dir
+	if len(h.Envs) > 0 {
+		cmd.Env = append(os.Environ(), h.Envs...)
+	}
 
 	if h.UsePluginCache {
 		rwmutex.RLock()


### PR DESCRIPTION
### Description of your changes

Adding the environment variables as used earlier in the function and elsewhere in the file.

This is the same change as upbound/provider-opentofu#19, but for the terraform provider.

Without this, envronment variables set on the workspace are passed to the workspace select command, but not the workspace new command. This causes an error when using environment variables to configure the workspace's backend.

In my specific use-case I am setting GOOGLE_IMPERSONATE_SERVICE_ACCOUNT to have the Google Terraform provider switch to a service account via workload identity.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

However, it fails with an error, even on the main branch:

```
❯ make reviewable
18:12:48 [ .. ] go generate linux_amd64
18:12:53 [ OK ] go generate linux_amd64
18:12:53 [ .. ] go mod tidy
18:12:53 [ OK ] go mod tidy
18:12:54 [ .. ] golangci-lint
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner. Replaced by revive.
apis/v1beta1/storeconfig_types.go:72:19: in.Status.GetCondition undefined (type StoreConfigStatus has no field or method GetCondition) (typecheck)
        return in.Status.GetCondition(ct)
                         ^
apis/v1beta1/storeconfig_types.go:77:12: in.Status.SetConditions undefined (type StoreConfigStatus has no field or method SetConditions) (typecheck)
        in.Status.SetConditions(c...)
                  ^
cmd/provider/main.go:56:32: undefined: kingpin (typecheck)
                app                        = kingpin.New(filepath.Base(os.Args[0]), "Terraform support for Crossplane.").DefaultEnvars()
                                             ^
cmd/provider/main.go:71:2: undefined: kingpin (typecheck)
        kingpin.MustParse(app.Parse(os.Args[1:]))
        ^
cmd/provider/main.go:80:3: undefined: kingpin (typecheck)
                kingpin.Fatalf("Unknown --log-encoding value: %s. Supported values are 'console' and 'json'", *logEncoding)
                ^
cmd/provider/main.go:95:2: undefined: kingpin (typecheck)
        kingpin.FatalIfError(err, "Cannot get API server rest config")
        ^
cmd/provider/main.go:115:2: undefined: kingpin (typecheck)
        kingpin.FatalIfError(err, "Cannot create controller manager")
        ^
cmd/provider/main.go:117:2: undefined: kingpin (typecheck)
        kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add terraform APIs to scheme")
        ^
cmd/provider/main.go:150:4: undefined: kingpin (typecheck)
                        kingpin.FatalIfError(err, "Cannot load ESS TLS config.")
                        ^
cmd/provider/main.go:156:3: undefined: kingpin (typecheck)
                kingpin.FatalIfError(resource.Ignore(kerrors.IsAlreadyExists, mgr.GetClient().Create(context.Background(), &v1beta1.StoreConfig{
                ^
cmd/provider/main.go:170:2: undefined: kingpin (typecheck)
        kingpin.FatalIfError(workspace.Setup(mgr, o, *timeout, *pollJitter), "Cannot setup Workspace controllers")
        ^
cmd/provider/main.go:171:2: undefined: kingpin (typecheck)
        kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
        ^
internal/controller/workspace/workspace.go:240:9: undefined: getter (typecheck)
                gc := getter.Client{
                      ^
internal/controller/workspace/workspace.go:245:10: undefined: getter (typecheck)
                        Mode: getter.ClientModeDir,
                              ^
internal/controller/workspace/workspace_test.go:1080:17: missing type in composite literal (typecheck)
                                                "string": {},
                                                          ^
internal/controller/workspace/workspace_test.go:1123:17: missing type in composite literal (typecheck)
                                                "string": {},
                                                          ^
internal/controller/workspace/workspace_test.go:1347:17: missing type in composite literal (typecheck)
                                                "string": {},
                                                          ^
../../../../usr/local/go/src/runtime/time.go:204:17: cannot range over 3 (untyped int constant) (typecheck)
        for i := range 3 {
                       ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:79:10: cannot infer T ($GOROOT/src/cmp/cmp.go:40:1) (typecheck)
                return cmp.Compare(aVal.Int(), bVal.Int())
                       ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:81:10: cannot infer T ($GOROOT/src/cmp/cmp.go:40:1) (typecheck)
                return cmp.Compare(aVal.Uint(), bVal.Uint())
                       ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:83:10: cannot infer T ($GOROOT/src/cmp/cmp.go:40:1) (typecheck)
                return cmp.Compare(aVal.String(), bVal.String())
                       ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:85:10: cannot infer T ($GOROOT/src/cmp/cmp.go:40:1) (typecheck)
                return cmp.Compare(aVal.Float(), bVal.Float())
                       ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:88:11: cannot infer T ($GOROOT/src/cmp/cmp.go:40:1) (typecheck)
                if c := cmp.Compare(real(a), real(b)); c != 0 {
                        ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:91:10: cannot infer T ($GOROOT/src/cmp/cmp.go:40:1) (typecheck)
                return cmp.Compare(imag(a), imag(b))
                       ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:103:10: cannot infer T ($GOROOT/src/cmp/cmp.go:40:1) (typecheck)
                return cmp.Compare(aVal.Pointer(), bVal.Pointer())
                       ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:108:10: cannot infer T ($GOROOT/src/cmp/cmp.go:40:1) (typecheck)
                return cmp.Compare(aVal.Pointer(), bVal.Pointer())
                       ^
../../../../usr/local/go/src/internal/fmtsort/sort.go:136:1: missing return (typecheck)
}
^
../../../../usr/local/go/src/reflect/iter.go:67:19: cannot range over v.Len() (value of type int) (typecheck)
                        for i := range v.Len() {
                                       ^
../../../../usr/local/go/src/reflect/iter.go:75:19: cannot range over v.Len() (value of type int) (typecheck)
                        for i := range v.Len() {
                                       ^
../../../../usr/local/go/src/reflect/iter.go:131:19: cannot range over v.Len() (value of type int) (typecheck)
                        for i := range v.Len() {
                                       ^
../../../../usr/local/go/src/reflect/iter.go:139:19: cannot range over v.Len() (value of type int) (typecheck)
                        for i := range v.Len() {
                                       ^
../../../../usr/local/go/src/reflect/type.go:2320:19: cannot range over num (variable of type int) (typecheck)
                        for i := range num {
                                       ^
../../../../usr/local/go/src/slices/iter.go:64:7: cannot infer E (/usr/local/go/src/slices/iter.go:57:14) (typecheck)
        s := Collect(seq)
             ^
../../../../usr/local/go/src/slices/iter.go:65:2: cannot infer S (/usr/local/go/src/slices/sort.go:16:11) (typecheck)
        Sort(s)
        ^
../../../../usr/local/go/src/slices/iter.go:72:7: cannot infer E (/usr/local/go/src/slices/iter.go:57:14) (typecheck)
        s := Collect(seq)
             ^
../../../../usr/local/go/src/slices/iter.go:73:2: cannot infer S (/usr/local/go/src/slices/sort.go:30:15) (typecheck)
        SortFunc(s, cmp)
        ^
../../../../usr/local/go/src/slices/iter.go:82:7: cannot infer E (/usr/local/go/src/slices/iter.go:57:14) (typecheck)
        s := Collect(seq)
             ^
../../../../usr/local/go/src/slices/iter.go:83:2: cannot infer S (/usr/local/go/src/slices/sort.go:37:21) (typecheck)
        SortStableFunc(s, cmp)
        ^
../../../../usr/local/go/src/io/pipe.go:22:4: a.Lock undefined (type *onceError has no field or method Lock) (typecheck)
        a.Lock()
          ^
../../../../usr/local/go/src/io/pipe.go:23:10: a.Unlock undefined (type *onceError has no field or method Unlock) (typecheck)
        defer a.Unlock()
                ^
../../../../usr/local/go/src/io/pipe.go:30:4: a.Lock undefined (type *onceError has no field or method Lock) (typecheck)
        a.Lock()
          ^
../../../../usr/local/go/src/io/pipe.go:31:10: a.Unlock undefined (type *onceError has no field or method Unlock) (typecheck)
        defer a.Unlock()
                ^
../../../../usr/local/go/src/os/file_unix.go:454:45: not enough arguments in call to fixCount
        have (unknown type)
        want (int, error) (typecheck)
                        n, e = fixCount(syscall.Readlink(name, b))
                                                                 ^
../../../../usr/local/go/src/syscall/syscall_unix.go:66:4: m.Lock undefined (type *mmapper has no field or method Lock) (typecheck)
        m.Lock()
          ^
../../../../usr/local/go/src/syscall/syscall_unix.go:67:10: m.Unlock undefined (type *mmapper has no field or method Unlock) (typecheck)
        defer m.Unlock()
                ^
../../../../usr/local/go/src/syscall/syscall_unix.go:79:4: m.Lock undefined (type *mmapper has no field or method Lock) (typecheck)
        m.Lock()
          ^
../../../../usr/local/go/src/syscall/syscall_unix.go:80:10: m.Unlock undefined (type *mmapper has no field or method Unlock) (typecheck)
        defer m.Unlock()
                ^
../../go/pkg/mod/k8s.io/api@v0.29.4/core/v1/generated.pb.go:12301:11: m.Items undefined (type *List has no field or method Items) (typecheck)
        if len(m.Items) > 0 {
                 ^
../../go/pkg/mod/k8s.io/api@v0.29.4/core/v1/generated.pb.go:12302:22: m.Items undefined (type *List has no field or method Items) (typecheck)
                for iNdEx := len(m.Items) - 1; iNdEx >= 0; iNdEx-- {
                                   ^
../../go/pkg/mod/k8s.io/api@v0.29.4/core/v1/generated.pb.go:12304:20: m.Items undefined (type *List has no field or method Items) (typecheck)
                                size, err := m.Items[iNdEx].MarshalToSizedBuffer(dAtA[:i])
                                               ^
18:13:02 [FAIL]
make[2]: *** [build/makelib/golang.mk:131: go.lint] Error 1
make[1]: *** [build/makelib/common.mk:372: lint] Error 2
make: *** [build/makelib/common.mk:440: reviewable] Error 2
```

### How has this code been tested

I tested the same change on the opentofu provider.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
